### PR TITLE
Fix bug where user credentials did not save between sessions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Assembly Versioning](https://msdn.microsoft.com/en-us/library/51ket42z(v=vs.71).aspx).
 
-## Upcoming
+## v0.96
 
 * Clears up some overlapping code in the app configuration file
 * Properly initializes username and password fields from variables to prevent change event handlers from wiping state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Assembly Versioning](https://msdn.microsoft.com/en-us/library/51ket42z(v=vs.71).aspx).
 
+## Upcoming
+
+* Clears up some overlapping code in the app configuration file
+* Properly initializes username and password fields from variables to prevent change event handlers from wiping state.
+
 ## v0.95
 
 * Add Owens cluster as default.

--- a/OSCConnect/App.config
+++ b/OSCConnect/App.config
@@ -2,8 +2,7 @@
 <configuration>
     <configSections>
         <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-            <section name="OSCConnect.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
-            <section name="AweSimConnect.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+            <section name="OSCConnect.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />            
         </sectionGroup>
     </configSections>
     <startup> 
@@ -48,43 +47,5 @@
                 <value>95</value>
             </setting>
         </OSCConnect.Properties.Settings>
-        <AweSimConnect.Properties.Settings>
-            <setting name="Username" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="Userpass" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="IsPassSaved" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="SSHHost" serializeAs="String">
-                <value>OAK</value>
-            </setting>
-            <setting name="AutoOpenApp" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="DetectClipboard" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="CommandLineUpdated" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="LaunchSSHOnImport" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="NewerVersionAvailable" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="AutoCheckNewVersion" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="WriteableUser" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="VNCQuality" serializeAs="String">
-                <value>95</value>
-            </setting>
-        </AweSimConnect.Properties.Settings>
     </userSettings>
 </configuration>

--- a/OSCConnect/Properties/AssemblyInfo.cs
+++ b/OSCConnect/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.95.*")]
-[assembly: AssemblyFileVersion("0.95")]
+[assembly: AssemblyVersion("0.96.*")]
+[assembly: AssemblyFileVersion("0.96")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]

--- a/OSCConnect/Views/ConnectMainForm.cs
+++ b/OSCConnect/Views/ConnectMainForm.cs
@@ -86,7 +86,7 @@ namespace OSCConnect.Views
             _connectionForms = new List<ConnectionForm>();
             _connection = new Connection();
             _settings = new AdvancedSettings();
-
+            
             // If the app can't write out a folder to deploy helper apps,
             // it's because the user doesn't have admin access to write.
             _settings.SetWriteableUser(FileController.CreateFilesFolder());
@@ -115,14 +115,8 @@ namespace OSCConnect.Views
             {
                 MessageBox.Show(ex.Message, ex.GetType().ToString());
             }
-
-            tbUsername.Text = _settings.GetUsername();
-            tbPassword.Text = _settings.GetPassword();
-            if (_settings.IsUserSaved())
-            {
-                cbRememberMe.Checked = true;
-            }
-
+            
+            PopulateUserCredentials(_settings);
             DisplayGroupBoxes();
             DisplayNewVersionOptions(_settings.NewerVersionAvailable());
 
@@ -133,6 +127,16 @@ namespace OSCConnect.Views
 
             timerMain.Start();
             
+        }
+
+        private void PopulateUserCredentials(AdvancedSettings settings)
+        {
+            String username = settings.GetUsername();
+            String password = settings.GetPassword();
+            bool rememberme = settings.IsUserSaved();
+            tbUsername.Text = username;
+            tbPassword.Text = password;
+            cbRememberMe.Checked = rememberme;
         }
 
 

--- a/OSCConnect/Views/ConnectMainForm.cs
+++ b/OSCConnect/Views/ConnectMainForm.cs
@@ -129,6 +129,9 @@ namespace OSCConnect.Views
             
         }
 
+        // Fills in the username and password fields from the settings. 
+        // Because of the listeners on the text field, we need to grab these values from 
+        //  the settings before populating the fields. 
         private void PopulateUserCredentials(AdvancedSettings settings)
         {
             String username = settings.GetUsername();

--- a/OSCConnect/Views/ConnectMainForm.cs
+++ b/OSCConnect/Views/ConnectMainForm.cs
@@ -134,9 +134,12 @@ namespace OSCConnect.Views
         //  the settings before populating the fields. 
         private void PopulateUserCredentials(AdvancedSettings settings)
         {
+            // Grab the username, password, and checked state from settings
             String username = settings.GetUsername();
             String password = settings.GetPassword();
             bool rememberme = settings.IsUserSaved();
+            
+            // Set the form fields from the cached settings.
             tbUsername.Text = username;
             tbPassword.Text = password;
             cbRememberMe.Checked = rememberme;


### PR DESCRIPTION
Resolves #56 

* Clears up some overlapping code in the app configuration file
* Properly initializes username and password fields from variables to prevent change event handlers from wiping state.